### PR TITLE
Fix #7

### DIFF
--- a/src/rockstar-parser.peg
+++ b/src/rockstar-parser.peg
@@ -42,7 +42,7 @@ PoeticString = v:Variable _ 'says' ' ' t:$[^\n]*
 PoeticNumber = n:PoeticDigits d:PoeticDecimal? {return {t: 'Literal', v: parseFloat(d?n+'.'+d:n)}}
 PoeticDecimal = '.' _ d:PoeticDigits {return d}
 PoeticDigits =
-	l:PoeticDigit _ r:PoeticDigits { return l+r }
+	l:PoeticDigit ( _ / [\',;:?!] )+ r:PoeticDigits { return l+r }
 	/ d: PoeticDigit { return d }
 PoeticDigit = t:[A-Za-z]+ {return (t.length%10).toString()}
 


### PR DESCRIPTION
Allows `',;:?!` in anywhere that would allow a space in poetic number literals.

`My dreams were ice. A life unfulfilled; wakin' everybody up, taking booze and pills` now correctly parses to
`{ "t": "Set", "v": { "t": "Variable", "n": "dreams" }, "e": { "t": "Literal", "v": 3.1415926535 } }`