### PR TITLE
Add version to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name": "rockstar-js",
+  "version": "0.0.1",
   "description": "JavaScript transpiler for the esoteric language 'Rockstar'",
   "homepage": "https://github.com/wolfgang42/rockstar-js",
   "bugs": "https://github.com/wolfgang42/rockstar-js/issues",


### PR DESCRIPTION
Both `npm install` and `yarn add` need the package.json to contain a version so that this package can be added using commands like `npm i https://github.com/wolfgang42/rockstar-js`.

I understand that you might not want to publish this on npm. I am fine using the longer command to add this package in `node_modules` but that fails as well because version is required. This is the error I see:

```
~/w/rockstar  yarn add https://github.com/wolfgang42/rockstar-js                                                                                                          yarn add v1.7.0
info No lockfile found.
[1/4] 🔍  Resolving packages...
error Can't add "rockstar-js": invalid package version undefined.
info Visit https://yarnpkg.com/en/docs/cli/add for documentation about this command.
```

There is a similar error for npm install as well.

This PR adds the version key to package.json so that the above commands can work.