### PR TITLE
Constants

### DIFF
--- a/examples/constants.rock
+++ b/examples/constants.rock
@@ -1,0 +1,4 @@
+Joe is nothing
+Billy is mysterious
+Jimmy is nowhere
+Al is nobody

--- a/src/rockstar-parser.peg
+++ b/src/rockstar-parser.peg
@@ -19,7 +19,7 @@ Pronoun = (
 
 TypeLiteral = v:TypeLiteralValue { return {t: 'Literal', v} }
 TypeLiteralValue =
-	('nothing'/'nobody'/'nowhere'/'empty'/'gone') {return 0} // TODO null?
+	('null'/'nothing'/'nobody'/'nowhere'/'empty'/'gone') {return null}
 	/ ('true'/'right'/'yes'/'ok') {return true}
     / ('false'/'wrong'/'no'/'lies') {return false}
     / 'mysterious' { return undefined}

--- a/src/rockstar-parser.peg
+++ b/src/rockstar-parser.peg
@@ -19,7 +19,7 @@ Pronoun = (
 
 TypeLiteral = v:TypeLiteralValue { return {t: 'Literal', v} }
 TypeLiteralValue =
-	('null'/'nothing'/'nobody'/'nowhere'/'empty'/'gone') {return null}
+	('null'/'nothing'/'nobody'/'nowhere'/'empty'/'gone') {return 0}
 	/ ('true'/'right'/'yes'/'ok') {return true}
     / ('false'/'wrong'/'no'/'lies') {return false}
     / 'mysterious' { return undefined}


### PR DESCRIPTION
"maybe" and "definitely maybe" are not implemented for now. 
According to specs : 

> Null - the null type. Evaluates as equal to zero and equal to false. The keywords nothing, nowhere, nobody, empty and gone are defined as aliases for null

So "nothing" and his other null aliases should be set to 0 and not to null : 

I added "null" to have it set to 0 too.

Closes #38.